### PR TITLE
feat: aanmeldflow quick wins + anti-abuse (Fase 1)

### DIFF
--- a/__tests__/lib/registration.test.ts
+++ b/__tests__/lib/registration.test.ts
@@ -9,6 +9,10 @@ describe('validateRegistration', () => {
     expect(r.data).toEqual({ naam: 'Jan', email: 'jan@example.nl', telefoon: '06-12345678', opmerking: 'hoi' });
   });
 
+  it('normaliseert e-mail naar lowercase (dubbel-detectie)', () => {
+    expect(validateRegistration({ ...valid, email: '  Jan@Example.NL ' }).data?.email).toBe('jan@example.nl');
+  });
+
   it('lege opmerking wordt null', () => {
     expect(validateRegistration({ ...valid, opmerking: '' }).data?.opmerking).toBeNull();
   });

--- a/app/api/aanmelden/route.ts
+++ b/app/api/aanmelden/route.ts
@@ -13,13 +13,26 @@ export async function POST(request: NextRequest) {
                 'unknown';
     
     const body = await request.json();
-    const { taakId } = body;
+    const { taakId, website, renderedAt } = body;
 
     if (!taakId || typeof taakId !== 'string') {
       return NextResponse.json(
         { message: 'Taak is verplicht' },
         { status: 400 }
       );
+    }
+
+    // Onzichtbare anti-abuse: een honeypot-veld dat echte gebruikers nooit zien/
+    // invullen, en een minimale invultijd. Een bot vult de honeypot of submit
+    // direct. Bewuste, gedocumenteerde keuze: doe alsof het lukte en sla niets op
+    // (verklap de bot niets) — geen stille fallback elders in de app.
+    const elapsedMs = Date.now() - Number(renderedAt);
+    const looksLikeBot =
+      (typeof website === 'string' && website.trim() !== '') ||
+      !Number.isFinite(elapsedMs) ||
+      elapsedMs < 3000;
+    if (looksLikeBot) {
+      return NextResponse.json({ success: true, message: 'Aanmelding succesvol' });
     }
 
     // Gedeelde validatie + sanitisatie (naam, e-mail, telefoon, opmerking + lengtes)
@@ -116,6 +129,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({
       success: true,
       message: 'Aanmelding succesvol',
+      wijzigToken: token, // voor de bevestigingspagina (zelfde token als in de mail)
     });
   } catch (error: any) {
     console.error('Registration error:', error?.message);

--- a/app/bevestiging/page.tsx
+++ b/app/bevestiging/page.tsx
@@ -1,33 +1,42 @@
 import Link from 'next/link';
 
-export default function BevestigingPage() {
+export default async function BevestigingPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ token?: string }>;
+}) {
+  const { token } = await searchParams;
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || '';
+  const wijzigLink = token ? `${siteUrl}/wijzig/${token}` : null;
+
   return (
     <main className="min-h-screen bg-gray-50 flex items-center justify-center">
       <div className="bg-white rounded-lg shadow-md p-8 max-w-md w-full text-center">
         <div className="mb-6">
           <div className="w-16 h-16 bg-success rounded-full flex items-center justify-center mx-auto mb-4">
-            <svg
-              className="w-8 h-8 text-white"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M5 13l4 4L19 7"
-              />
+            <svg className="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
             </svg>
           </div>
           <h1 className="text-2xl font-bold mb-2">Aanmelding geslaagd!</h1>
         </div>
-        
+
         <p className="text-gray-600 mb-6">
           Je aanmelding is succesvol verwerkt. Je ontvangt binnen enkele minuten een
-          bevestigingsmail met alle details en een link om je aanmelding eventueel te
-          wijzigen of annuleren.
+          bevestigingsmail met alle details.
         </p>
+
+        {wijzigLink && (
+          <div className="bg-gray-50 border border-gray-200 rounded-md p-4 mb-6 text-left">
+            <p className="text-sm text-gray-700 mb-2">
+              Wil je je aanmelding wijzigen of annuleren? Dat kan via deze link
+              (deze staat ook in je bevestigingsmail):
+            </p>
+            <a href={wijzigLink} className="text-primary text-sm break-all hover:underline">
+              {wijzigLink}
+            </a>
+          </div>
+        )}
 
         <div className="space-y-3">
           <Link

--- a/components/AanmeldForm.tsx
+++ b/components/AanmeldForm.tsx
@@ -12,12 +12,16 @@ export default function AanmeldForm({ taakId, taakNaam }: AanmeldFormProps) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
-  
+  // Tijdstip waarop het formulier verscheen (voor de anti-bot tijd-check).
+  const [renderedAt] = useState(() => Date.now());
+  // Honeypot: blijft leeg bij echte gebruikers; bots vullen 'm.
+  const [website, setWebsite] = useState('');
+
   const [formData, setFormData] = useState({
     naam: '',
     email: '',
     telefoon: '',
-    opmerking: ''
+    opmerking: '',
   });
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -28,38 +32,46 @@ export default function AanmeldForm({ taakId, taakNaam }: AanmeldFormProps) {
     try {
       const response = await fetch('/api/aanmelden', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          taakId,
-          ...formData
-        }),
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ taakId, ...formData, website, renderedAt }),
       });
 
       const data = await response.json();
-
       if (!response.ok) {
         throw new Error(data.message || 'Er is een fout opgetreden');
       }
 
-      router.push('/bevestiging');
-    } catch (err: any) {
-      setError(err.message || 'Er is een fout opgetreden');
+      const target = data.wijzigToken
+        ? `/bevestiging?token=${encodeURIComponent(data.wijzigToken)}`
+        : '/bevestiging';
+      router.push(target);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Er is een fout opgetreden');
     } finally {
       setLoading(false);
     }
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    setFormData({
-      ...formData,
-      [e.target.name]: e.target.value
-    });
+    setFormData({ ...formData, [e.target.name]: e.target.value });
   };
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
+      {/* Honeypot — verborgen voor mensen, zichtbaar voor bots. Niet aankomen. */}
+      <div aria-hidden="true" style={{ position: 'absolute', left: '-9999px', width: 1, height: 1, overflow: 'hidden' }}>
+        <label htmlFor="website">Vul dit veld niet in</label>
+        <input
+          type="text"
+          id="website"
+          name="website"
+          tabIndex={-1}
+          autoComplete="off"
+          value={website}
+          onChange={(e) => setWebsite(e.target.value)}
+        />
+      </div>
+
       <div>
         <label htmlFor="naam" className="block text-sm font-medium text-text-dark mb-1">
           Naam *
@@ -120,6 +132,20 @@ export default function AanmeldForm({ taakId, taakNaam }: AanmeldFormProps) {
           onChange={handleChange}
           className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
         />
+      </div>
+
+      <div className="flex items-start gap-2">
+        <input
+          type="checkbox"
+          id="akkoord"
+          name="akkoord"
+          required
+          className="mt-1 h-4 w-4"
+        />
+        <label htmlFor="akkoord" className="text-sm text-gray-600">
+          Ik ga ermee akkoord dat mijn naam, e-mail en telefoonnummer worden gebruikt voor de
+          organisatie van de Startzondag. Deze gegevens worden na afloop verwijderd.
+        </label>
       </div>
 
       {error && (

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -20,7 +20,8 @@ export interface RegistrationResult {
 // Gedeelde validatie + sanitisatie voor aanmelden én wijzigen.
 export function validateRegistration(input: RegistrationInput): RegistrationResult {
   const naam = typeof input.naam === 'string' ? input.naam.trim() : '';
-  const email = typeof input.email === 'string' ? input.email.trim() : '';
+  // E-mail genormaliseerd (lowercase) voor consistente opslag + dubbel-detectie.
+  const email = typeof input.email === 'string' ? input.email.trim().toLowerCase() : '';
   const telefoon = typeof input.telefoon === 'string' ? input.telefoon.trim() : '';
   const opmerking = typeof input.opmerking === 'string' ? input.opmerking.trim() : '';
 


### PR DESCRIPTION
Fase 1 van de userflow-verbeteringen — geen schemawijziging, nul drempel.

- **E-mail genormaliseerd** (trim+lowercase) → consistente opslag + dubbel-detectie (`Jan@X.nl` == `jan@x.nl`).
- **Bevestigingspagina toont de wijzig-/annuleer-link** (met tekst, "staat ook in je mail") — vangnet als de mail niet aankomt. API geeft de token terug, form redirect met `?token=`.
- **Onzichtbare anti-abuse**: honeypot-veld + minimale invultijd (3s). Bots worden stilletjes gedropt; echte gebruikers (zeker de oudjes) merken niets.
- **Privacy**: korte AVG-notitie + verplichte akkoord-checkbox.

Verified: type-check, lint, jest 34/34, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)