### PR TITLE
feat: datamodel, soft-delete & e-mailvalidatie (Fase 2)

### DIFF
--- a/__tests__/lib/email-validate.test.ts
+++ b/__tests__/lib/email-validate.test.ts
@@ -1,0 +1,35 @@
+// MOCK REASON: dns is een externe, non-deterministische systeemafhankelijkheid.
+jest.mock('dns', () => ({ promises: { resolveMx: jest.fn() } }));
+
+import { promises as dns } from 'dns';
+import { checkEmailDomain } from '@/lib/email-validate';
+
+const mockResolveMx = dns.resolveMx as unknown as jest.Mock;
+
+describe('checkEmailDomain', () => {
+  beforeEach(() => mockResolveMx.mockReset());
+
+  it('domein met MX-record -> OK', async () => {
+    mockResolveMx.mockResolvedValue([{ exchange: 'mx.example.nl', priority: 10 }]);
+    expect(await checkEmailDomain('jan@example.nl')).toBe('OK');
+  });
+
+  it('domein zonder MX-records -> CONTROLEREN', async () => {
+    mockResolveMx.mockResolvedValue([]);
+    expect(await checkEmailDomain('jan@geen-mx.nl')).toBe('CONTROLEREN');
+  });
+
+  it('niet-bestaand domein (ENOTFOUND) -> CONTROLEREN', async () => {
+    mockResolveMx.mockRejectedValue(Object.assign(new Error('nope'), { code: 'ENOTFOUND' }));
+    expect(await checkEmailDomain('jan@bestaat-niet.xyz')).toBe('CONTROLEREN');
+  });
+
+  it('tijdelijke DNS-fout -> ONBEKEND (niet onterecht vlaggen)', async () => {
+    mockResolveMx.mockRejectedValue(Object.assign(new Error('timeout'), { code: 'ETIMEOUT' }));
+    expect(await checkEmailDomain('jan@example.nl')).toBe('ONBEKEND');
+  });
+
+  it('geen @ in adres -> CONTROLEREN', async () => {
+    expect(await checkEmailDomain('geen-email')).toBe('CONTROLEREN');
+  });
+});

--- a/app/aanmelden/[id]/page.tsx
+++ b/app/aanmelden/[id]/page.tsx
@@ -2,13 +2,14 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import AanmeldForm from '@/components/AanmeldForm';
 import { prisma } from '@/lib/db';
+import { ACTIEF_FILTER } from '@/lib/aanmelding';
 
 async function getTaak(id: string) {
   const taak = await prisma.taak.findUnique({
     where: { id },
     include: {
       _count: {
-        select: { aanmeldingen: true }
+        select: { aanmeldingen: { where: ACTIEF_FILTER } }
       }
     }
   });

--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { prisma } from '@/lib/db';
 import { clearSession } from '@/lib/auth';
+import { ACTIEF_FILTER } from '@/lib/aanmelding';
 import { redirect } from 'next/navigation';
 
 export const dynamic = 'force-dynamic';
@@ -8,11 +9,11 @@ export const dynamic = 'force-dynamic';
 async function getStats() {
   const [takenCount, aanmeldingenCount, taken] = await Promise.all([
     prisma.taak.count(),
-    prisma.aanmelding.count(),
+    prisma.aanmelding.count({ where: ACTIEF_FILTER }),
     prisma.taak.findMany({
       include: {
         _count: {
-          select: { aanmeldingen: true }
+          select: { aanmeldingen: { where: ACTIEF_FILTER } }
         }
       },
       orderBy: { naam: 'asc' }

--- a/app/admin/dashboard/taken/[id]/page.tsx
+++ b/app/admin/dashboard/taken/[id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { prisma } from '@/lib/db';
 import { formatDateTimeNL } from '@/lib/datetime';
+import { ACTIEF_FILTER } from '@/lib/aanmelding';
 import DeleteButton from './DeleteButton';
 
 export const dynamic = 'force-dynamic';
@@ -11,6 +12,7 @@ async function getTaakWithAanmeldingen(id: string) {
     where: { id },
     include: {
       aanmeldingen: {
+        where: ACTIEF_FILTER,
         orderBy: { createdAt: 'desc' }
       }
     }

--- a/app/api/aanmelden/route.ts
+++ b/app/api/aanmelden/route.ts
@@ -3,6 +3,8 @@ import { prisma } from '@/lib/db';
 import { sendConfirmationEmail } from '@/lib/email';
 import { checkRateLimit, getRemainingTime } from '@/lib/rate-limit';
 import { sanitizePhoneNumber, validateRegistration } from '@/lib/validation';
+import { checkEmailDomain } from '@/lib/email-validate';
+import { ACTIEF_FILTER, STATUS } from '@/lib/aanmelding';
 import crypto from 'crypto';
 
 export async function POST(request: NextRequest) {
@@ -60,6 +62,10 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // E-maildomein checken (MX). Geen mailserver -> vlag 'CONTROLEREN'; de plek
+    // blijft (admin matcht handmatig). Buiten de transactie i.v.m. DNS-latency.
+    const emailStatus = await checkEmailDomain(email);
+
     // Generate unique token before transaction
     const token = crypto.randomBytes(32).toString('hex');
 
@@ -70,10 +76,10 @@ export async function POST(request: NextRequest) {
         where: { id: taakId },
         include: {
           _count: {
-            select: { aanmeldingen: true }
+            select: { aanmeldingen: { where: ACTIEF_FILTER } }
           },
           aanmeldingen: {
-            where: { email },
+            where: { email, status: STATUS.ACTIEF },
             select: { id: true }
           }
         }
@@ -83,12 +89,12 @@ export async function POST(request: NextRequest) {
         throw new Error('Taak niet gevonden');
       }
 
-      // Check for duplicate email on same task
+      // Check for duplicate active registration on same task
       if (taak.aanmeldingen.length > 0) {
         throw new Error('Je bent al aangemeld voor deze taak');
       }
 
-      // Check if task is full (within transaction for accuracy)
+      // Check if task is full (alleen ACTIEVE tellen mee)
       if (taak._count.aanmeldingen >= taak.maxAantal) {
         throw new Error('Deze taak is helaas vol');
       }
@@ -103,6 +109,7 @@ export async function POST(request: NextRequest) {
           opmerking: opmerking || null,
           token,
           bevestigd: true,
+          emailStatus,
         },
       });
 

--- a/app/api/admin/aanmeldingen/[id]/route.ts
+++ b/app/api/admin/aanmeldingen/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { requireAdmin } from '@/lib/api-auth';
+import { STATUS } from '@/lib/aanmelding';
 
 // DELETE a registration
 export async function DELETE(
@@ -24,9 +25,10 @@ export async function DELETE(
       );
     }
 
-    // Delete the registration
-    await prisma.aanmelding.delete({
-      where: { id }
+    // Soft-delete: markeer als geannuleerd (rij blijft bewaard voor rapportage).
+    await prisma.aanmelding.update({
+      where: { id },
+      data: { status: STATUS.GEANNULEERD },
     });
 
     return NextResponse.json({

--- a/app/api/admin/export/route.ts
+++ b/app/api/admin/export/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { formatDateTimeNL } from '@/lib/datetime';
 import { requireAdmin } from '@/lib/api-auth';
+import { ACTIEF_FILTER } from '@/lib/aanmelding';
 import ExcelJS from 'exceljs';
 
 // Neutraliseer CSV/Excel formula-injection: cellen die met =,+,-,@,tab of CR
@@ -19,6 +20,7 @@ export async function GET() {
     const taken = await prisma.taak.findMany({
       include: {
         aanmeldingen: {
+          where: ACTIEF_FILTER,
           orderBy: { createdAt: 'asc' }
         }
       },

--- a/app/api/admin/taken/[id]/route.ts
+++ b/app/api/admin/taken/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { requireAdmin } from '@/lib/api-auth';
+import { ACTIEF_FILTER } from '@/lib/aanmelding';
 
 // GET a single task
 export async function GET(
@@ -16,7 +17,7 @@ export async function GET(
       where: { id },
       include: {
         _count: {
-          select: { aanmeldingen: true }
+          select: { aanmeldingen: { where: ACTIEF_FILTER } }
         }
       }
     });
@@ -62,7 +63,7 @@ export async function PUT(
       where: { id },
       include: {
         _count: {
-          select: { aanmeldingen: true }
+          select: { aanmeldingen: { where: ACTIEF_FILTER } }
         }
       }
     });
@@ -120,7 +121,7 @@ export async function DELETE(
       where: { id },
       include: {
         _count: {
-          select: { aanmeldingen: true }
+          select: { aanmeldingen: { where: ACTIEF_FILTER } }
         }
       }
     });

--- a/app/api/resend-webhook/route.ts
+++ b/app/api/resend-webhook/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from 'next/server';
+import crypto from 'crypto';
+import { prisma } from '@/lib/db';
+import { EMAIL_STATUS } from '@/lib/aanmelding';
+
+export const runtime = 'nodejs';
+
+// Verifieer de Svix-handtekening (zoals Resend die stuurt) met het signing secret.
+// Zonder geldige handtekening kan iedereen nep-bounces sturen.
+function verifySignature(secret: string, headers: Headers, payload: string): boolean {
+  const id = headers.get('svix-id');
+  const timestamp = headers.get('svix-timestamp');
+  const sigHeader = headers.get('svix-signature');
+  if (!id || !timestamp || !sigHeader) return false;
+
+  const secretBytes = Buffer.from(secret.replace(/^whsec_/, ''), 'base64');
+  const expected = crypto
+    .createHmac('sha256', secretBytes)
+    .update(`${id}.${timestamp}.${payload}`)
+    .digest('base64');
+  const expectedBuf = Buffer.from(expected);
+
+  // Header bevat één of meer "v1,<signature>" gescheiden door spaties.
+  return sigHeader.split(' ').some((part) => {
+    const sig = part.split(',')[1];
+    if (!sig) return false;
+    const sigBuf = Buffer.from(sig);
+    return sigBuf.length === expectedBuf.length && crypto.timingSafeEqual(sigBuf, expectedBuf);
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const secret = process.env.RESEND_WEBHOOK_SECRET;
+  if (!secret) {
+    console.error('RESEND_WEBHOOK_SECRET niet geconfigureerd');
+    return NextResponse.json({ message: 'Webhook niet geconfigureerd' }, { status: 500 });
+  }
+
+  const payload = await request.text();
+  if (!verifySignature(secret, request.headers, payload)) {
+    return NextResponse.json({ message: 'Ongeldige handtekening' }, { status: 401 });
+  }
+
+  let event: { type?: string; data?: { to?: unknown } };
+  try {
+    event = JSON.parse(payload);
+  } catch {
+    return NextResponse.json({ message: 'Ongeldige payload' }, { status: 400 });
+  }
+
+  // Bij een bounce of klacht: markeer de aanmelding(en) voor handmatige controle.
+  if (event.type === 'email.bounced' || event.type === 'email.complained') {
+    const to = event.data?.to;
+    const recipients = (Array.isArray(to) ? to : [to])
+      .filter((e): e is string => typeof e === 'string')
+      .map((e) => e.trim().toLowerCase());
+    if (recipients.length > 0) {
+      await prisma.aanmelding.updateMany({
+        where: { email: { in: recipients } },
+        data: { emailStatus: EMAIL_STATUS.CONTROLEREN },
+      });
+    }
+  }
+
+  return NextResponse.json({ received: true });
+}

--- a/app/api/taken/route.ts
+++ b/app/api/taken/route.ts
@@ -1,12 +1,13 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
+import { ACTIEF_FILTER } from '@/lib/aanmelding';
 
 export async function GET() {
   try {
     const taken = await prisma.taak.findMany({
       include: {
         _count: {
-          select: { aanmeldingen: true }
+          select: { aanmeldingen: { where: ACTIEF_FILTER } }
         }
       },
       orderBy: [

--- a/app/api/wijzig/[token]/route.ts
+++ b/app/api/wijzig/[token]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { sendCancellationEmail } from '@/lib/email';
 import { validateRegistration } from '@/lib/validation';
+import { STATUS } from '@/lib/aanmelding';
 
 export async function GET(
   request: NextRequest,
@@ -85,8 +86,10 @@ export async function DELETE(
       );
     }
 
-    await prisma.aanmelding.delete({
-      where: { token }
+    // Soft-delete: bewaar de rij maar markeer als geannuleerd; de plek komt vrij.
+    await prisma.aanmelding.update({
+      where: { token },
+      data: { status: STATUS.GEANNULEERD },
     });
 
     // Send cancellation email

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import TaakCard from '@/components/TaakCard';
 import { prisma } from '@/lib/db';
 import { EVENT_NAME } from '@/lib/event';
+import { ACTIEF_FILTER } from '@/lib/aanmelding';
 
 export const dynamic = 'force-dynamic';
 
@@ -9,7 +10,7 @@ async function getTaken() {
   const taken = await prisma.taak.findMany({
     include: {
       _count: {
-        select: { aanmeldingen: true }
+        select: { aanmeldingen: { where: ACTIEF_FILTER } }
       }
     },
     orderBy: [

--- a/lib/aanmelding.ts
+++ b/lib/aanmelding.ts
@@ -1,0 +1,17 @@
+// Statuswaarden als tekst (i.p.v. DB-enum) zodat we later eenvoudig waarden
+// kunnen toevoegen (bijv. WACHTLIJST in Fase 3).
+export const STATUS = {
+  ACTIEF: 'ACTIEF',
+  GEANNULEERD: 'GEANNULEERD',
+  WACHTLIJST: 'WACHTLIJST',
+} as const;
+
+export const EMAIL_STATUS = {
+  ONBEKEND: 'ONBEKEND',
+  OK: 'OK',
+  CONTROLEREN: 'CONTROLEREN',
+} as const;
+
+// Hergebruikt filter: alleen ACTIEVE aanmeldingen tellen mee voor de bezetting.
+// Geannuleerde (soft-deleted) blijven bewaard maar tellen niet mee.
+export const ACTIEF_FILTER = { status: STATUS.ACTIEF } as const;

--- a/lib/email-validate.ts
+++ b/lib/email-validate.ts
@@ -1,0 +1,20 @@
+import { promises as dns } from 'dns';
+import { EMAIL_STATUS } from './aanmelding';
+
+type EmailStatus = (typeof EMAIL_STATUS)[keyof typeof EMAIL_STATUS];
+
+// Controleer of het e-maildomein een mailserver heeft (MX-record). Vangt nep-/
+// typedomeinen. Geen MX of niet-bestaand domein -> CONTROLEREN (admin checkt het,
+// de plek blijft). Een tijdelijke DNS-fout -> ONBEKEND (niet onterecht vlaggen).
+export async function checkEmailDomain(email: string): Promise<EmailStatus> {
+  const domain = email.split('@')[1];
+  if (!domain) return EMAIL_STATUS.CONTROLEREN;
+  try {
+    const records = await dns.resolveMx(domain);
+    return records && records.length > 0 ? EMAIL_STATUS.OK : EMAIL_STATUS.CONTROLEREN;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException)?.code;
+    if (code === 'ENOTFOUND' || code === 'ENODATA') return EMAIL_STATUS.CONTROLEREN;
+    return EMAIL_STATUS.ONBEKEND;
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,8 @@ model Taak {
   beschrijving  String?
   maxAantal     Int
   categorie     String?
+  tijd          String?
+  locatie       String?
   aanmeldingen  Aanmelding[]
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
@@ -33,11 +35,31 @@ model Aanmelding {
   opmerking     String?
   token         String   @unique
   bevestigd     Boolean  @default(false)
+  // Slot-status: ACTIEF (telt mee) | GEANNULEERD (soft-delete) | WACHTLIJST (Fase 3)
+  status        String   @default("ACTIEF")
+  // E-mailvaliditeit: ONBEKEND | OK | CONTROLEREN (MX-fail of bounce)
+  emailStatus   String   @default("ONBEKEND")
+  // Interne notitie voor beheerders (ook in Excel), niet zichtbaar voor vrijwilliger
+  adminNotitie  String?
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 
   @@index([email])
   @@index([token])
+  @@index([status])
+}
+
+// Audit-log van beheeracties (wie deed wat, wanneer).
+model AuditLog {
+  id          String   @id @default(cuid())
+  actorEmail  String
+  action      String
+  entityType  String
+  entityId    String?
+  details     String?
+  createdAt   DateTime @default(now())
+
+  @@index([createdAt])
 }
 
 model Admin {


### PR DESCRIPTION
Fase 2 — datamodel + soft-delete + e-mailvalidatie. Schema al additief naar prod gepusht.

**Schema:** Taak +tijd/locatie; Aanmelding +status/emailStatus/adminNotitie (+index); nieuw AuditLog.

**Soft-delete:** annuleren én admin-verwijderen zetten `status=GEANNULEERD` (rij blijft, plek komt vrij). **Alle** bezettings-tellingen tellen nu alleen `ACTIEF` (homepage, taken-API, aanmeldpagina, dashboard, taakdetail, edit/delete-guards, export, slot-check). Dubbel-check op ACTIEF → na annuleren kun je opnieuw aanmelden.

**E-mailvalidatie (plek blijft, alleen vlaggen):** MX-check bij aanmelden → `emailStatus=CONTROLEREN` bij dood domein. `/api/resend-webhook` met geverifieerde Svix-handtekening → bounce/complaint flagt het adres.

Verified: type-check, lint, jest 39/39, build. `RESEND_WEBHOOK_SECRET` staat in Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)