### PR TITLE
feat: wachtlijst met automatische promotie (Fase 3)

### DIFF
--- a/app/aanmelden/[id]/page.tsx
+++ b/app/aanmelden/[id]/page.tsx
@@ -50,13 +50,13 @@ export default async function AanmeldPage({ params }: { params: Promise<{ id: st
             </p>
           </div>
 
-          {isVol ? (
-            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
-              Deze taak is helaas vol. Er kunnen geen nieuwe aanmeldingen meer worden geaccepteerd.
+          {isVol && (
+            <div className="bg-amber-50 border border-amber-200 text-amber-800 px-4 py-3 rounded mb-4">
+              Deze taak is vol. Je kunt je wel op de <strong>wachtlijst</strong> zetten — komt er een
+              plek vrij, dan laten we het je weten.
             </div>
-          ) : (
-            <AanmeldForm taakId={taak.id} taakNaam={taak.naam} />
           )}
+          <AanmeldForm taakId={taak.id} taakNaam={taak.naam} isVol={isVol} />
         </div>
       </div>
     </main>

--- a/app/admin/dashboard/taken/[id]/page.tsx
+++ b/app/admin/dashboard/taken/[id]/page.tsx
@@ -2,12 +2,12 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { prisma } from '@/lib/db';
 import { formatDateTimeNL } from '@/lib/datetime';
-import { ACTIEF_FILTER } from '@/lib/aanmelding';
+import { ACTIEF_FILTER, STATUS } from '@/lib/aanmelding';
 import DeleteButton from './DeleteButton';
 
 export const dynamic = 'force-dynamic';
 
-async function getTaakWithAanmeldingen(id: string) {
+async function getTaakData(id: string) {
   const taak = await prisma.taak.findUnique({
     where: { id },
     include: {
@@ -17,17 +17,22 @@ async function getTaakWithAanmeldingen(id: string) {
       }
     }
   });
-
-  return taak;
+  if (!taak) return null;
+  const wachtlijst = await prisma.aanmelding.findMany({
+    where: { taakId: id, status: STATUS.WACHTLIJST },
+    orderBy: { createdAt: 'asc' },
+  });
+  return { taak, wachtlijst };
 }
 
 export default async function TaakDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const taak = await getTaakWithAanmeldingen(id);
+  const data = await getTaakData(id);
 
-  if (!taak) {
+  if (!data) {
     notFound();
   }
+  const { taak, wachtlijst } = data;
 
   return (
     <main className="min-h-screen bg-gray-50">
@@ -137,6 +142,29 @@ export default async function TaakDetailPage({ params }: { params: Promise<{ id:
             )}
           </div>
         </div>
+
+        {wachtlijst.length > 0 && (
+          <div className="bg-white rounded-lg shadow mt-6">
+            <div className="p-6 border-b">
+              <h2 className="text-xl font-semibold">Wachtlijst ({wachtlijst.length})</h2>
+              <p className="text-sm text-gray-500 mt-1">
+                Op volgorde van aanmelding. Komt er een plek vrij, dan wordt de bovenste automatisch
+                ingedeeld en gemaild.
+              </p>
+            </div>
+            <ol className="divide-y divide-gray-200">
+              {wachtlijst.map((w, i) => (
+                <li key={w.id} className="px-6 py-3 flex items-center gap-4 text-sm">
+                  <span className="text-gray-400 w-6">{i + 1}.</span>
+                  <span className="font-medium">{w.naam}</span>
+                  <span className="text-gray-500">{w.email}</span>
+                  <span className="text-gray-500">{w.telefoon}</span>
+                  <span className="ml-auto text-gray-400">{formatDateTimeNL(w.createdAt)}</span>
+                </li>
+              ))}
+            </ol>
+          </div>
+        )}
       </div>
     </main>
   );

--- a/app/api/aanmelden/route.ts
+++ b/app/api/aanmelden/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
-import { sendConfirmationEmail } from '@/lib/email';
+import { sendConfirmationEmail, sendWaitlistEmail } from '@/lib/email';
 import { checkRateLimit, getRemainingTime } from '@/lib/rate-limit';
 import { sanitizePhoneNumber, validateRegistration } from '@/lib/validation';
 import { checkEmailDomain } from '@/lib/email-validate';
@@ -15,7 +15,7 @@ export async function POST(request: NextRequest) {
                 'unknown';
     
     const body = await request.json();
-    const { taakId, website, renderedAt } = body;
+    const { taakId, website, renderedAt, wachtlijst } = body;
 
     if (!taakId || typeof taakId !== 'string') {
       return NextResponse.json(
@@ -79,7 +79,8 @@ export async function POST(request: NextRequest) {
             select: { aanmeldingen: { where: ACTIEF_FILTER } }
           },
           aanmeldingen: {
-            where: { email, status: STATUS.ACTIEF },
+            // Dubbel-detectie: al actief óf al op de wachtlijst voor deze taak.
+            where: { email, status: { in: [STATUS.ACTIEF, STATUS.WACHTLIJST] } },
             select: { id: true }
           }
         }
@@ -89,17 +90,21 @@ export async function POST(request: NextRequest) {
         throw new Error('Taak niet gevonden');
       }
 
-      // Check for duplicate active registration on same task
+      // Check for duplicate registration on same task
       if (taak.aanmeldingen.length > 0) {
         throw new Error('Je bent al aangemeld voor deze taak');
       }
 
-      // Check if task is full (alleen ACTIEVE tellen mee)
-      if (taak._count.aanmeldingen >= taak.maxAantal) {
-        throw new Error('Deze taak is helaas vol');
+      // Vol? Dan wachtlijst (als de gebruiker daarvoor koos), anders weigeren.
+      const isVol = taak._count.aanmeldingen >= taak.maxAantal;
+      let status: string = STATUS.ACTIEF;
+      if (isVol) {
+        if (!wachtlijst) {
+          throw new Error('Deze taak is helaas vol');
+        }
+        status = STATUS.WACHTLIJST;
       }
 
-      // Create registration within transaction
       const aanmelding = await tx.aanmelding.create({
         data: {
           taakId,
@@ -110,33 +115,39 @@ export async function POST(request: NextRequest) {
           token,
           bevestigd: true,
           emailStatus,
+          status,
         },
       });
 
-      return { aanmelding, taak };
+      return { aanmelding, taak, waitlisted: status === STATUS.WACHTLIJST };
     });
 
-    // Send confirmation email
+    // Mail: wachtlijst-bevestiging of normale bevestiging.
     const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
     const wijzigLink = `${siteUrl}/wijzig/${token}`;
 
     try {
-      await sendConfirmationEmail(email, {
-        naam,
-        taakNaam: result.taak.naam,
-        telefoon: sanitizedPhone,
-        email,
-        wijzigLink,
-      });
+      if (result.waitlisted) {
+        await sendWaitlistEmail(email, { naam, taakNaam: result.taak.naam, wijzigLink });
+      } else {
+        await sendConfirmationEmail(email, {
+          naam,
+          taakNaam: result.taak.naam,
+          telefoon: sanitizedPhone,
+          email,
+          wijzigLink,
+        });
+      }
     } catch {
-      // Bevestigingsmail mag de aanmelding niet laten falen; geen PII loggen.
+      // Mail mag de aanmelding niet laten falen; geen PII loggen.
       console.error('Bevestigingsmail kon niet verzonden worden');
     }
 
     return NextResponse.json({
       success: true,
-      message: 'Aanmelding succesvol',
-      wijzigToken: token, // voor de bevestigingspagina (zelfde token als in de mail)
+      message: result.waitlisted ? 'Op wachtlijst geplaatst' : 'Aanmelding succesvol',
+      wijzigToken: token,
+      waitlisted: result.waitlisted,
     });
   } catch (error: any) {
     console.error('Registration error:', error?.message);

--- a/app/api/admin/aanmeldingen/[id]/route.ts
+++ b/app/api/admin/aanmeldingen/[id]/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { requireAdmin } from '@/lib/api-auth';
 import { STATUS } from '@/lib/aanmelding';
+import { promoteFromWaitlist } from '@/lib/waitlist';
+import { sendWaitlistPromotionEmail } from '@/lib/email';
 
 // DELETE a registration
 export async function DELETE(
@@ -30,6 +32,23 @@ export async function DELETE(
       where: { id },
       data: { status: STATUS.GEANNULEERD },
     });
+
+    // Kwam er een ACTIEVE plek vrij? Promoveer de eerste van de wachtlijst + mail.
+    if (aanmelding.status === STATUS.ACTIEF) {
+      try {
+        const promoted = await promoteFromWaitlist(aanmelding.taakId);
+        if (promoted) {
+          const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+          await sendWaitlistPromotionEmail(promoted.email, {
+            naam: promoted.naam,
+            taakNaam: promoted.taakNaam,
+            wijzigLink: `${siteUrl}/wijzig/${promoted.token}`,
+          });
+        }
+      } catch {
+        console.error('Wachtlijst-promotie na verwijderen mislukt');
+      }
+    }
 
     return NextResponse.json({
       success: true,

--- a/app/api/wijzig/[token]/route.ts
+++ b/app/api/wijzig/[token]/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
-import { sendCancellationEmail } from '@/lib/email';
+import { sendCancellationEmail, sendWaitlistPromotionEmail } from '@/lib/email';
 import { validateRegistration } from '@/lib/validation';
 import { STATUS } from '@/lib/aanmelding';
+import { promoteFromWaitlist } from '@/lib/waitlist';
 
 export async function GET(
   request: NextRequest,
@@ -97,6 +98,23 @@ export async function DELETE(
       naam: aanmelding.naam,
       taakNaam: aanmelding.taak.naam,
     });
+
+    // Kwam er een ACTIEVE plek vrij? Promoveer de eerste van de wachtlijst + mail.
+    if (aanmelding.status === STATUS.ACTIEF) {
+      try {
+        const promoted = await promoteFromWaitlist(aanmelding.taakId);
+        if (promoted) {
+          const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+          await sendWaitlistPromotionEmail(promoted.email, {
+            naam: promoted.naam,
+            taakNaam: promoted.taakNaam,
+            wijzigLink: `${siteUrl}/wijzig/${promoted.token}`,
+          });
+        }
+      } catch {
+        console.error('Wachtlijst-promotie na annulering mislukt');
+      }
+    }
 
     return NextResponse.json({
       success: true,

--- a/app/bevestiging/page.tsx
+++ b/app/bevestiging/page.tsx
@@ -3,11 +3,12 @@ import Link from 'next/link';
 export default async function BevestigingPage({
   searchParams,
 }: {
-  searchParams: Promise<{ token?: string }>;
+  searchParams: Promise<{ token?: string; wachtlijst?: string }>;
 }) {
-  const { token } = await searchParams;
+  const { token, wachtlijst } = await searchParams;
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || '';
   const wijzigLink = token ? `${siteUrl}/wijzig/${token}` : null;
+  const opWachtlijst = wachtlijst === '1';
 
   return (
     <main className="min-h-screen bg-gray-50 flex items-center justify-center">
@@ -18,19 +19,23 @@ export default async function BevestigingPage({
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
             </svg>
           </div>
-          <h1 className="text-2xl font-bold mb-2">Aanmelding geslaagd!</h1>
+          <h1 className="text-2xl font-bold mb-2">
+            {opWachtlijst ? 'Op de wachtlijst!' : 'Aanmelding geslaagd!'}
+          </h1>
         </div>
 
         <p className="text-gray-600 mb-6">
-          Je aanmelding is succesvol verwerkt. Je ontvangt binnen enkele minuten een
-          bevestigingsmail met alle details.
+          {opWachtlijst
+            ? 'Deze taak was vol, dus we hebben je op de wachtlijst gezet. Komt er een plek vrij, dan krijg je vanzelf bericht. Je ontvangt een bevestigingsmail.'
+            : 'Je aanmelding is succesvol verwerkt. Je ontvangt binnen enkele minuten een bevestigingsmail met alle details.'}
         </p>
 
         {wijzigLink && (
           <div className="bg-gray-50 border border-gray-200 rounded-md p-4 mb-6 text-left">
             <p className="text-sm text-gray-700 mb-2">
-              Wil je je aanmelding wijzigen of annuleren? Dat kan via deze link
-              (deze staat ook in je bevestigingsmail):
+              {opWachtlijst
+                ? 'Wil je je van de wachtlijst afmelden? Dat kan via deze link (staat ook in je mail):'
+                : 'Wil je je aanmelding wijzigen of annuleren? Dat kan via deze link (deze staat ook in je bevestigingsmail):'}
             </p>
             <a href={wijzigLink} className="text-primary text-sm break-all hover:underline">
               {wijzigLink}

--- a/components/AanmeldForm.tsx
+++ b/components/AanmeldForm.tsx
@@ -6,9 +6,10 @@ import { useRouter } from 'next/navigation';
 interface AanmeldFormProps {
   taakId: string;
   taakNaam: string;
+  isVol?: boolean;
 }
 
-export default function AanmeldForm({ taakId, taakNaam }: AanmeldFormProps) {
+export default function AanmeldForm({ taakId, isVol = false }: AanmeldFormProps) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
@@ -33,7 +34,7 @@ export default function AanmeldForm({ taakId, taakNaam }: AanmeldFormProps) {
       const response = await fetch('/api/aanmelden', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ taakId, ...formData, website, renderedAt }),
+        body: JSON.stringify({ taakId, ...formData, website, renderedAt, wachtlijst: isVol }),
       });
 
       const data = await response.json();
@@ -41,10 +42,11 @@ export default function AanmeldForm({ taakId, taakNaam }: AanmeldFormProps) {
         throw new Error(data.message || 'Er is een fout opgetreden');
       }
 
-      const target = data.wijzigToken
-        ? `/bevestiging?token=${encodeURIComponent(data.wijzigToken)}`
-        : '/bevestiging';
-      router.push(target);
+      const params = new URLSearchParams();
+      if (data.wijzigToken) params.set('token', data.wijzigToken);
+      if (data.waitlisted) params.set('wachtlijst', '1');
+      const qs = params.toString();
+      router.push(qs ? `/bevestiging?${qs}` : '/bevestiging');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Er is een fout opgetreden');
     } finally {
@@ -159,7 +161,7 @@ export default function AanmeldForm({ taakId, taakNaam }: AanmeldFormProps) {
         disabled={loading}
         className="w-full bg-primary text-white py-2 px-4 rounded hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors font-medium"
       >
-        {loading ? 'Bezig met aanmelden...' : 'Aanmelden'}
+        {loading ? 'Bezig...' : isVol ? 'Op wachtlijst zetten' : 'Aanmelden'}
       </button>
     </form>
   );

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -159,3 +159,52 @@ export async function sendMagicLinkEmail(to: string, link: string, ttlMinutes: n
     `),
   });
 }
+
+// Bevestiging dat iemand op de wachtlijst staat (taak was vol).
+export async function sendWaitlistEmail(to: string, data: { naam: string; taakNaam: string; wijzigLink: string }) {
+  const naam = escapeHtml(data.naam);
+  const taakNaam = escapeHtml(data.taakNaam);
+  const wijzigLink = escapeHtml(data.wijzigLink);
+  return sendEmailWithRetry({
+    from: FROM,
+    to,
+    subject: `Wachtlijst Startzondag - ${data.taakNaam}`,
+    html: shell(`
+      <h2 style="color: #1f2937; margin-top: 0;">Beste ${naam},</h2>
+      <p style="color: #4b5563; line-height: 1.6;">
+        De taak <strong>${taakNaam}</strong> is op dit moment vol. We hebben je op de
+        <strong>wachtlijst</strong> gezet. Komt er een plek vrij, dan laten we het je weten —
+        je hoeft zelf niets te doen.
+      </p>
+      <p style="color: #4b5563; line-height: 1.6;">
+        Wil je je van de wachtlijst afmelden? Dat kan via deze link:
+      </p>
+      <p style="color: #6b7280; font-size: 12px;">${wijzigLink}</p>
+      ${SIGNATURE}
+    `),
+  });
+}
+
+// Iemand van de wachtlijst is gepromoveerd naar een echte plek.
+export async function sendWaitlistPromotionEmail(to: string, data: { naam: string; taakNaam: string; wijzigLink: string }) {
+  const naam = escapeHtml(data.naam);
+  const taakNaam = escapeHtml(data.taakNaam);
+  const wijzigLink = escapeHtml(data.wijzigLink);
+  return sendEmailWithRetry({
+    from: FROM,
+    to,
+    subject: `Er is een plek vrij - ${data.taakNaam}`,
+    html: shell(`
+      <h2 style="color: #1f2937; margin-top: 0;">Goed nieuws, ${naam}!</h2>
+      <p style="color: #4b5563; line-height: 1.6;">
+        Er is een plek vrijgekomen voor <strong>${taakNaam}</strong> en je stond bovenaan de
+        wachtlijst. Je bent nu <strong>definitief ingedeeld</strong> voor deze taak.
+      </p>
+      <p style="color: #4b5563; line-height: 1.6;">
+        Kun je toch niet? Meld je dan af via deze link, dan kan iemand anders erbij:
+      </p>
+      <p style="color: #6b7280; font-size: 12px;">${wijzigLink}</p>
+      ${SIGNATURE}
+    `),
+  });
+}

--- a/lib/waitlist.ts
+++ b/lib/waitlist.ts
@@ -1,0 +1,42 @@
+import { prisma } from './db';
+import { STATUS } from './aanmelding';
+
+export interface PromotedAanmelding {
+  id: string;
+  naam: string;
+  email: string;
+  token: string;
+  taakNaam: string;
+}
+
+// Promoveer de oudste wachtlijst-aanmelding van een taak naar ACTIEF zodra er een
+// plek vrij is (bijv. na een annulering). Retourneert de gepromote aanmelding
+// (voor de mail) of null als er niets te promoveren valt.
+export async function promoteFromWaitlist(taakId: string): Promise<PromotedAanmelding | null> {
+  return prisma.$transaction(async (tx) => {
+    const taak = await tx.taak.findUnique({
+      where: { id: taakId },
+      include: { _count: { select: { aanmeldingen: { where: { status: STATUS.ACTIEF } } } } },
+    });
+    if (!taak) return null;
+    if (taak._count.aanmeldingen >= taak.maxAantal) return null; // nog geen plek vrij
+
+    const next = await tx.aanmelding.findFirst({
+      where: { taakId, status: STATUS.WACHTLIJST },
+      orderBy: { createdAt: 'asc' },
+    });
+    if (!next) return null;
+
+    const promoted = await tx.aanmelding.update({
+      where: { id: next.id },
+      data: { status: STATUS.ACTIEF },
+    });
+    return {
+      id: promoted.id,
+      naam: promoted.naam,
+      email: promoted.email,
+      token: promoted.token,
+      taakNaam: taak.naam,
+    };
+  });
+}


### PR DESCRIPTION
Fase 3 — wachtlijst met automatische promotie.

- **Vol → wachtlijst**: formulier in wachtlijst-modus ("Op wachtlijst zetten"); API maakt `status=WACHTLIJST`. Dubbel-detectie blokkeert ook een bestaande wachtlijst-plek.
- **Auto-promotie**: annuleren/admin-verwijderen van een ACTIEVE plek promoveert de oudste wachtlijst-aanmelding → ACTIEF + mail ("er is een plek vrij"). Alleen als er echt een plek vrijkomt.
- E-mails: wachtlijst-bevestiging + promotie-mail. Bevestigingspagina heeft een wachtlijst-variant. Admin-taakdetail toont de wachtlijst op volgorde.

Verified: type-check, lint, jest 39/39, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)