### PR TITLE
feat: aanmeldingen beheren in admin (Fase 4a)

### DIFF
--- a/app/admin/dashboard/aanmeldingen/AanmeldingActies.tsx
+++ b/app/admin/dashboard/aanmeldingen/AanmeldingActies.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+export default function AanmeldingActies({ id, naam, status }: { id: string; naam: string; status: string }) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+
+  const handleDelete = async () => {
+    if (!confirm(`Aanmelding van ${naam} annuleren? De plek komt vrij (en de eerste op de wachtlijst schuift door).`)) return;
+    setBusy(true);
+    const res = await fetch(`/api/admin/aanmeldingen/${id}`, { method: 'DELETE' });
+    setBusy(false);
+    if (res.ok) router.refresh();
+    else alert('Annuleren mislukt');
+  };
+
+  return (
+    <div className="flex gap-3 whitespace-nowrap">
+      <Link href={`/admin/dashboard/aanmeldingen/${id}/edit`} className="text-primary hover:underline">
+        Bewerken
+      </Link>
+      {status !== 'GEANNULEERD' && (
+        <button onClick={handleDelete} disabled={busy} className="text-red-600 hover:underline disabled:opacity-50">
+          Annuleren
+        </button>
+      )}
+    </div>
+  );
+}

--- a/app/admin/dashboard/aanmeldingen/[id]/edit/page.tsx
+++ b/app/admin/dashboard/aanmeldingen/[id]/edit/page.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { prisma } from '@/lib/db';
+import AanmeldingBeheerForm from '@/components/AanmeldingBeheerForm';
+
+export const dynamic = 'force-dynamic';
+
+export default async function EditAanmeldingPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const a = await prisma.aanmelding.findUnique({
+    where: { id },
+    include: { taak: { select: { naam: true } } },
+  });
+  if (!a) notFound();
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <div className="bg-white shadow">
+        <div className="container mx-auto px-4 py-4 flex items-center gap-4">
+          <Link href="/admin/dashboard/aanmeldingen" className="text-primary hover:underline">← Aanmeldingen</Link>
+          <h1 className="text-2xl font-bold">Aanmelding bewerken</h1>
+        </div>
+      </div>
+      <div className="container mx-auto px-4 py-8 max-w-2xl">
+        <div className="bg-white rounded-lg shadow p-6">
+          <AanmeldingBeheerForm
+            bestaand={{
+              id: a.id,
+              naam: a.naam,
+              email: a.email,
+              telefoon: a.telefoon,
+              opmerking: a.opmerking,
+              adminNotitie: a.adminNotitie,
+              taakNaam: a.taak.naam,
+            }}
+          />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/admin/dashboard/aanmeldingen/nieuw/page.tsx
+++ b/app/admin/dashboard/aanmeldingen/nieuw/page.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+import { prisma } from '@/lib/db';
+import AanmeldingBeheerForm from '@/components/AanmeldingBeheerForm';
+
+export const dynamic = 'force-dynamic';
+
+export default async function NieuweAanmeldingPage() {
+  const taken = await prisma.taak.findMany({ select: { id: true, naam: true }, orderBy: { naam: 'asc' } });
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <div className="bg-white shadow">
+        <div className="container mx-auto px-4 py-4 flex items-center gap-4">
+          <Link href="/admin/dashboard/aanmeldingen" className="text-primary hover:underline">← Aanmeldingen</Link>
+          <h1 className="text-2xl font-bold">Handmatig toevoegen</h1>
+        </div>
+      </div>
+      <div className="container mx-auto px-4 py-8 max-w-2xl">
+        <div className="bg-white rounded-lg shadow p-6">
+          <p className="text-sm text-gray-500 mb-4">
+            De persoon krijgt automatisch een bevestigingsmail met een wijzig-/annuleer-link.
+          </p>
+          <AanmeldingBeheerForm taken={taken} />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/admin/dashboard/aanmeldingen/page.tsx
+++ b/app/admin/dashboard/aanmeldingen/page.tsx
@@ -1,0 +1,148 @@
+import Link from 'next/link';
+import { prisma } from '@/lib/db';
+import { formatDateTimeNL } from '@/lib/datetime';
+import { STATUS, EMAIL_STATUS } from '@/lib/aanmelding';
+import { Prisma } from '@/generated/prisma/client';
+import AanmeldingActies from './AanmeldingActies';
+
+export const dynamic = 'force-dynamic';
+
+const STATUS_LABEL: Record<string, { label: string; klasse: string }> = {
+  ACTIEF: { label: 'Actief', klasse: 'bg-green-100 text-green-800' },
+  WACHTLIJST: { label: 'Wachtlijst', klasse: 'bg-amber-100 text-amber-800' },
+  GEANNULEERD: { label: 'Geannuleerd', klasse: 'bg-gray-100 text-gray-500' },
+};
+
+export default async function AanmeldingenPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string; taakId?: string; status?: string; emailStatus?: string }>;
+}) {
+  const sp = await searchParams;
+  const q = (sp.q ?? '').trim();
+
+  const where: Prisma.AanmeldingWhereInput = {};
+  if (q) {
+    where.OR = [
+      { naam: { contains: q, mode: 'insensitive' } },
+      { email: { contains: q, mode: 'insensitive' } },
+      { telefoon: { contains: q } },
+    ];
+  }
+  if (sp.taakId) where.taakId = sp.taakId;
+  if (sp.status) where.status = sp.status;
+  if (sp.emailStatus) where.emailStatus = sp.emailStatus;
+
+  const [aanmeldingen, taken, teControleren] = await Promise.all([
+    prisma.aanmelding.findMany({
+      where,
+      include: { taak: { select: { naam: true } } },
+      orderBy: { createdAt: 'desc' },
+      take: 500,
+    }),
+    prisma.taak.findMany({ select: { id: true, naam: true }, orderBy: { naam: 'asc' } }),
+    prisma.aanmelding.count({ where: { emailStatus: EMAIL_STATUS.CONTROLEREN, status: { not: STATUS.GEANNULEERD } } }),
+  ]);
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <div className="bg-white shadow">
+        <div className="container mx-auto px-4 py-4 flex items-center gap-4">
+          <Link href="/admin/dashboard" className="text-primary hover:underline">← Dashboard</Link>
+          <h1 className="text-2xl font-bold">Aanmeldingen</h1>
+          <Link
+            href="/admin/dashboard/aanmeldingen/nieuw"
+            className="ml-auto bg-primary text-white px-4 py-2 rounded hover:bg-primary-hover text-sm font-medium"
+          >
+            + Handmatig toevoegen
+          </Link>
+        </div>
+      </div>
+
+      <div className="container mx-auto px-4 py-6">
+        {teControleren > 0 && (
+          <Link
+            href="/admin/dashboard/aanmeldingen?emailStatus=CONTROLEREN"
+            className="block mb-4 bg-amber-50 border border-amber-200 text-amber-800 px-4 py-3 rounded text-sm"
+          >
+            ⚠️ {teControleren} aanmelding(en) met een e-mailadres om te controleren — klik om te bekijken.
+          </Link>
+        )}
+
+        <form method="get" className="bg-white rounded-lg shadow p-4 mb-4 grid grid-cols-1 md:grid-cols-5 gap-3">
+          <input
+            type="text"
+            name="q"
+            defaultValue={q}
+            placeholder="Zoek op naam, e-mail of telefoon"
+            className="md:col-span-2 px-3 py-2 border border-gray-300 rounded-md text-sm"
+          />
+          <select name="taakId" defaultValue={sp.taakId ?? ''} className="px-3 py-2 border border-gray-300 rounded-md text-sm">
+            <option value="">Alle taken</option>
+            {taken.map((t) => (
+              <option key={t.id} value={t.id}>{t.naam}</option>
+            ))}
+          </select>
+          <select name="status" defaultValue={sp.status ?? ''} className="px-3 py-2 border border-gray-300 rounded-md text-sm">
+            <option value="">Alle statussen</option>
+            <option value="ACTIEF">Actief</option>
+            <option value="WACHTLIJST">Wachtlijst</option>
+            <option value="GEANNULEERD">Geannuleerd</option>
+          </select>
+          <div className="flex gap-2">
+            <select name="emailStatus" defaultValue={sp.emailStatus ?? ''} className="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm">
+              <option value="">Alle e-mail</option>
+              <option value="CONTROLEREN">Te controleren</option>
+              <option value="OK">OK</option>
+              <option value="ONBEKEND">Onbekend</option>
+            </select>
+            <button type="submit" className="bg-gray-800 text-white px-4 py-2 rounded text-sm">Zoek</button>
+          </div>
+        </form>
+
+        <p className="text-sm text-gray-500 mb-2">{aanmeldingen.length} resultaten</p>
+
+        <div className="bg-white rounded-lg shadow overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                {['Naam', 'E-mail', 'Telefoon', 'Taak', 'Status', 'Aangemeld', 'Notitie', ''].map((h) => (
+                  <th key={h} className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {aanmeldingen.map((a) => {
+                const s = STATUS_LABEL[a.status] ?? { label: a.status, klasse: 'bg-gray-100' };
+                return (
+                  <tr key={a.id}>
+                    <td className="px-4 py-3 font-medium whitespace-nowrap">{a.naam}</td>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      {a.email}
+                      {a.emailStatus === EMAIL_STATUS.CONTROLEREN && (
+                        <span className="ml-1 text-amber-600" title="E-mailadres controleren">⚠️</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap">{a.telefoon}</td>
+                    <td className="px-4 py-3 whitespace-nowrap">{a.taak.naam}</td>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      <span className={`px-2 py-0.5 rounded-full text-xs ${s.klasse}`}>{s.label}</span>
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap text-gray-500">{formatDateTimeNL(a.createdAt)}</td>
+                    <td className="px-4 py-3 text-gray-500 max-w-xs truncate" title={a.adminNotitie ?? ''}>{a.adminNotitie ?? '-'}</td>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      <AanmeldingActies id={a.id} naam={a.naam} status={a.status} />
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+          {aanmeldingen.length === 0 && (
+            <div className="text-center py-8 text-gray-500">Geen aanmeldingen gevonden</div>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -91,6 +91,12 @@ export default async function AdminDashboard() {
               <h2 className="text-xl font-semibold text-text-dark">Taken Overzicht</h2>
               <div className="space-x-2">
                 <Link
+                  href="/admin/dashboard/aanmeldingen"
+                  className="bg-gray-800 text-white px-4 py-2 rounded hover:bg-gray-900 transition-colors"
+                >
+                  Aanmeldingen
+                </Link>
+                <Link
                   href="/admin/dashboard/taken/nieuw"
                   className="bg-primary text-white px-4 py-2 rounded hover:bg-primary-hover transition-colors"
                 >

--- a/app/api/admin/aanmeldingen/[id]/route.ts
+++ b/app/api/admin/aanmeldingen/[id]/route.ts
@@ -1,9 +1,62 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { requireAdmin } from '@/lib/api-auth';
+import { getSession } from '@/lib/auth';
 import { STATUS } from '@/lib/aanmelding';
 import { promoteFromWaitlist } from '@/lib/waitlist';
 import { sendWaitlistPromotionEmail } from '@/lib/email';
+import { validateRegistration, sanitizePhoneNumber } from '@/lib/validation';
+import { logAudit } from '@/lib/audit';
+
+// PUT: aanmelding bewerken (naam/e-mail/telefoon/opmerking + admin-notitie).
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const denied = await requireAdmin();
+  if (denied) return denied;
+  const session = await getSession();
+  try {
+    const { id } = await params;
+    const body = await request.json();
+
+    const validated = validateRegistration(body);
+    if (validated.error || !validated.data) {
+      return NextResponse.json({ message: validated.error }, { status: 400 });
+    }
+    const adminNotitie =
+      typeof body.adminNotitie === 'string' ? body.adminNotitie.trim().slice(0, 1000) || null : null;
+
+    const existing = await prisma.aanmelding.findUnique({ where: { id } });
+    if (!existing) {
+      return NextResponse.json({ message: 'Aanmelding niet gevonden' }, { status: 404 });
+    }
+
+    await prisma.aanmelding.update({
+      where: { id },
+      data: {
+        naam: validated.data.naam,
+        email: validated.data.email,
+        telefoon: sanitizePhoneNumber(validated.data.telefoon),
+        opmerking: validated.data.opmerking,
+        adminNotitie,
+      },
+    });
+
+    await logAudit({
+      actorEmail: session?.email ?? 'onbekend',
+      action: 'aanmelding.bewerkt',
+      entityType: 'Aanmelding',
+      entityId: id,
+      details: validated.data.naam,
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Aanmelding bewerken mislukt');
+    return NextResponse.json({ message: 'Er is een fout opgetreden' }, { status: 500 });
+  }
+}
 
 // DELETE a registration
 export async function DELETE(
@@ -31,6 +84,14 @@ export async function DELETE(
     await prisma.aanmelding.update({
       where: { id },
       data: { status: STATUS.GEANNULEERD },
+    });
+
+    await logAudit({
+      actorEmail: (await getSession())?.email ?? 'onbekend',
+      action: 'aanmelding.geannuleerd',
+      entityType: 'Aanmelding',
+      entityId: id,
+      details: aanmelding.naam,
     });
 
     // Kwam er een ACTIEVE plek vrij? Promoveer de eerste van de wachtlijst + mail.

--- a/app/api/admin/aanmeldingen/route.ts
+++ b/app/api/admin/aanmeldingen/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from 'next/server';
+import crypto from 'crypto';
+import { prisma } from '@/lib/db';
+import { requireAdmin } from '@/lib/api-auth';
+import { getSession } from '@/lib/auth';
+import { validateRegistration, sanitizePhoneNumber } from '@/lib/validation';
+import { ACTIEF_FILTER, STATUS } from '@/lib/aanmelding';
+import { sendConfirmationEmail } from '@/lib/email';
+import { logAudit } from '@/lib/audit';
+
+// Handmatig een aanmelding toevoegen (beheerder). Triggert de bevestigingsmail.
+export async function POST(request: NextRequest) {
+  const denied = await requireAdmin();
+  if (denied) return denied;
+  const session = await getSession();
+
+  try {
+    const body = await request.json();
+    const { taakId } = body;
+    if (!taakId || typeof taakId !== 'string') {
+      return NextResponse.json({ message: 'Taak is verplicht' }, { status: 400 });
+    }
+
+    const validated = validateRegistration(body);
+    if (validated.error || !validated.data) {
+      return NextResponse.json({ message: validated.error }, { status: 400 });
+    }
+    const { naam, email, opmerking } = validated.data;
+    const sanitizedPhone = sanitizePhoneNumber(validated.data.telefoon);
+    const adminNotitie =
+      typeof body.adminNotitie === 'string' ? body.adminNotitie.trim().slice(0, 1000) || null : null;
+    const token = crypto.randomBytes(32).toString('hex');
+
+    const result = await prisma.$transaction(async (tx) => {
+      const taak = await tx.taak.findUnique({
+        where: { id: taakId },
+        include: {
+          _count: { select: { aanmeldingen: { where: ACTIEF_FILTER } } },
+          aanmeldingen: {
+            where: { email, status: { in: [STATUS.ACTIEF, STATUS.WACHTLIJST] } },
+            select: { id: true },
+          },
+        },
+      });
+      if (!taak) throw new Error('Taak niet gevonden');
+      if (taak.aanmeldingen.length > 0) throw new Error('Dit e-mailadres is al aangemeld voor deze taak');
+      if (taak._count.aanmeldingen >= taak.maxAantal) {
+        throw new Error('Deze taak is vol — verhoog eerst het maximum of kies een andere taak');
+      }
+      const aanmelding = await tx.aanmelding.create({
+        data: {
+          taakId,
+          naam,
+          email,
+          telefoon: sanitizedPhone,
+          opmerking: opmerking || null,
+          adminNotitie,
+          token,
+          bevestigd: true,
+          status: STATUS.ACTIEF,
+        },
+      });
+      return { aanmelding, taak };
+    });
+
+    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+    try {
+      await sendConfirmationEmail(email, {
+        naam,
+        taakNaam: result.taak.naam,
+        telefoon: sanitizedPhone,
+        email,
+        wijzigLink: `${siteUrl}/wijzig/${token}`,
+      });
+    } catch {
+      console.error('Bevestigingsmail (handmatig) kon niet verzonden worden');
+    }
+
+    await logAudit({
+      actorEmail: session?.email ?? 'onbekend',
+      action: 'aanmelding.handmatig-toegevoegd',
+      entityType: 'Aanmelding',
+      entityId: result.aanmelding.id,
+      details: `${naam} <${email}> voor "${result.taak.naam}"`,
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : '';
+    if (msg.includes('aangemeld') || msg.includes('niet gevonden') || msg.includes('vol')) {
+      return NextResponse.json({ message: msg }, { status: 400 });
+    }
+    console.error('Handmatig toevoegen mislukt');
+    return NextResponse.json({ message: 'Er is een fout opgetreden' }, { status: 500 });
+  }
+}

--- a/app/api/admin/export/route.ts
+++ b/app/api/admin/export/route.ts
@@ -75,6 +75,7 @@ export async function GET() {
       { header: 'Email', key: 'email', width: 30 },
       { header: 'Telefoon', key: 'telefoon', width: 15 },
       { header: 'Opmerking', key: 'opmerking', width: 40 },
+      { header: 'Notitie (admin)', key: 'notitie', width: 30 },
       { header: 'Aangemeld op', key: 'aangemeldOp', width: 20 },
       { header: 'Bevestigd', key: 'bevestigd', width: 10 }
     ];
@@ -88,6 +89,7 @@ export async function GET() {
           email: safeCell(aanmelding.email),
           telefoon: safeCell(aanmelding.telefoon),
           opmerking: safeCell(aanmelding.opmerking),
+          notitie: safeCell(aanmelding.adminNotitie),
           aangemeldOp: formatDateTimeNL(aanmelding.createdAt),
           bevestigd: aanmelding.bevestigd ? 'Ja' : 'Nee'
         });

--- a/components/AanmeldingBeheerForm.tsx
+++ b/components/AanmeldingBeheerForm.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface Taak {
+  id: string;
+  naam: string;
+}
+
+interface Bestaand {
+  id: string;
+  naam: string;
+  email: string;
+  telefoon: string;
+  opmerking: string | null;
+  adminNotitie: string | null;
+  taakNaam: string;
+}
+
+export default function AanmeldingBeheerForm({ taken, bestaand }: { taken?: Taak[]; bestaand?: Bestaand }) {
+  const router = useRouter();
+  const isEdit = !!bestaand;
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [form, setForm] = useState({
+    taakId: '',
+    naam: bestaand?.naam ?? '',
+    email: bestaand?.email ?? '',
+    telefoon: bestaand?.telefoon ?? '',
+    opmerking: bestaand?.opmerking ?? '',
+    adminNotitie: bestaand?.adminNotitie ?? '',
+  });
+
+  const set = (k: string, v: string) => setForm((f) => ({ ...f, [k]: v }));
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    try {
+      const url = isEdit ? `/api/admin/aanmeldingen/${bestaand!.id}` : '/api/admin/aanmeldingen';
+      const res = await fetch(url, {
+        method: isEdit ? 'PUT' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.message || 'Er ging iets mis');
+      router.push('/admin/dashboard/aanmeldingen');
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Er ging iets mis');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const inputCls = 'w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary';
+
+  return (
+    <form onSubmit={submit} className="space-y-4">
+      {isEdit ? (
+        <div>
+          <span className="block text-sm font-medium text-gray-700 mb-1">Taak</span>
+          <p className="px-3 py-2 bg-gray-50 rounded-md text-gray-700">{bestaand!.taakNaam}</p>
+        </div>
+      ) : (
+        <div>
+          <label htmlFor="taakId" className="block text-sm font-medium text-gray-700 mb-1">Taak *</label>
+          <select id="taakId" required value={form.taakId} onChange={(e) => set('taakId', e.target.value)} className={inputCls}>
+            <option value="">Kies een taak</option>
+            {(taken ?? []).map((t) => (
+              <option key={t.id} value={t.id}>{t.naam}</option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      <div>
+        <label htmlFor="naam" className="block text-sm font-medium text-gray-700 mb-1">Naam *</label>
+        <input id="naam" required value={form.naam} onChange={(e) => set('naam', e.target.value)} className={inputCls} />
+      </div>
+      <div>
+        <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">E-mail *</label>
+        <input id="email" type="email" required value={form.email} onChange={(e) => set('email', e.target.value)} className={inputCls} />
+      </div>
+      <div>
+        <label htmlFor="telefoon" className="block text-sm font-medium text-gray-700 mb-1">Telefoon *</label>
+        <input id="telefoon" required value={form.telefoon} onChange={(e) => set('telefoon', e.target.value)} className={inputCls} />
+      </div>
+      <div>
+        <label htmlFor="opmerking" className="block text-sm font-medium text-gray-700 mb-1">Opmerking</label>
+        <textarea id="opmerking" rows={2} value={form.opmerking} onChange={(e) => set('opmerking', e.target.value)} className={inputCls} />
+      </div>
+      <div>
+        <label htmlFor="adminNotitie" className="block text-sm font-medium text-gray-700 mb-1">
+          Notitie (alleen voor beheerders, ook in Excel)
+        </label>
+        <textarea id="adminNotitie" rows={2} value={form.adminNotitie} onChange={(e) => set('adminNotitie', e.target.value)} className={inputCls} placeholder='bijv. "zet erg vieze koffie ;-)"' />
+      </div>
+
+      {error && <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">{error}</div>}
+
+      <div className="flex gap-3">
+        <button type="submit" disabled={loading} className="bg-primary text-white py-2 px-4 rounded hover:bg-primary-hover disabled:opacity-50 font-medium">
+          {loading ? 'Bezig...' : isEdit ? 'Opslaan' : 'Toevoegen + bevestiging mailen'}
+        </button>
+        <button type="button" onClick={() => router.back()} className="py-2 px-4 rounded border border-gray-300">Annuleren</button>
+      </div>
+    </form>
+  );
+}

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -1,0 +1,24 @@
+import { prisma } from './db';
+
+// Leg een beheeractie vast. Mag de hoofdactie nooit laten falen.
+export async function logAudit(params: {
+  actorEmail: string;
+  action: string;
+  entityType: string;
+  entityId?: string;
+  details?: string;
+}): Promise<void> {
+  try {
+    await prisma.auditLog.create({
+      data: {
+        actorEmail: params.actorEmail,
+        action: params.action,
+        entityType: params.entityType,
+        entityId: params.entityId ?? null,
+        details: params.details ?? null,
+      },
+    });
+  } catch {
+    console.error('Audit-log kon niet geschreven worden');
+  }
+}


### PR DESCRIPTION
Fase 4a — aanmeldingen beheren in de admin.

- **Nieuwe pagina** `/admin/dashboard/aanmeldingen`: zoeken (naam/e-mail/telefoon) + filteren op taak/status/e-mailstatus. Badge + snelfilter voor **e-mail te controleren**.
- **Handmatig toevoegen** (+ bevestigingsmail, respecteert capaciteit) en **bewerken** (naam/e-mail/telefoon/opmerking + interne **admin-notitie**).
- Admin-notitie ook als **kolom in de Excel-export**.
- **Audit-logging** op toevoegen/bewerken/annuleren.

Verified: type-check, lint, jest 39/39, build. (Taak-audit + audit-weergave + tijd/locatie volgen in 4b.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)