### PR TITLE
feat: tijd/locatie per taak + audit-logboek (Fase 4b)

### DIFF
--- a/app/aanmelden/[id]/page.tsx
+++ b/app/aanmelden/[id]/page.tsx
@@ -45,6 +45,13 @@ export default async function AanmeldPage({ params }: { params: Promise<{ id: st
             {taak.beschrijving && (
               <p className="text-gray-600 mb-2">{taak.beschrijving}</p>
             )}
+            {(taak.tijd || taak.locatie) && (
+              <p className="text-sm text-gray-600 mb-2">
+                {taak.tijd && <span>🕒 {taak.tijd}</span>}
+                {taak.tijd && taak.locatie && <span> · </span>}
+                {taak.locatie && <span>📍 {taak.locatie}</span>}
+              </p>
+            )}
             <p className="text-sm text-gray-500">
               {taak._count.aanmeldingen} van {taak.maxAantal} plekken bezet
             </p>

--- a/app/admin/dashboard/audit/page.tsx
+++ b/app/admin/dashboard/audit/page.tsx
@@ -1,0 +1,55 @@
+import Link from 'next/link';
+import { prisma } from '@/lib/db';
+import { formatDateTimeNL } from '@/lib/datetime';
+
+export const dynamic = 'force-dynamic';
+
+const ACTIE_LABEL: Record<string, string> = {
+  'taak.aangemaakt': 'Taak aangemaakt',
+  'taak.bewerkt': 'Taak bewerkt',
+  'taak.verwijderd': 'Taak verwijderd',
+  'aanmelding.handmatig-toegevoegd': 'Aanmelding toegevoegd',
+  'aanmelding.bewerkt': 'Aanmelding bewerkt',
+  'aanmelding.geannuleerd': 'Aanmelding geannuleerd',
+};
+
+export default async function AuditPage() {
+  const logs = await prisma.auditLog.findMany({ orderBy: { createdAt: 'desc' }, take: 200 });
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <div className="bg-white shadow">
+        <div className="container mx-auto px-4 py-4 flex items-center gap-4">
+          <Link href="/admin/dashboard" className="text-primary hover:underline">← Dashboard</Link>
+          <h1 className="text-2xl font-bold">Logboek beheeracties</h1>
+        </div>
+      </div>
+
+      <div className="container mx-auto px-4 py-6">
+        <p className="text-sm text-gray-500 mb-2">Laatste {logs.length} acties</p>
+        <div className="bg-white rounded-lg shadow overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                {['Wanneer', 'Actie', 'Door', 'Details'].map((h) => (
+                  <th key={h} className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {logs.map((l) => (
+                <tr key={l.id}>
+                  <td className="px-4 py-3 whitespace-nowrap text-gray-500">{formatDateTimeNL(l.createdAt)}</td>
+                  <td className="px-4 py-3 whitespace-nowrap font-medium">{ACTIE_LABEL[l.action] ?? l.action}</td>
+                  <td className="px-4 py-3 whitespace-nowrap text-gray-600">{l.actorEmail}</td>
+                  <td className="px-4 py-3 text-gray-600">{l.details ?? '-'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {logs.length === 0 && <div className="text-center py-8 text-gray-500">Nog geen acties gelogd</div>}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -50,14 +50,19 @@ export default async function AdminDashboard() {
         <div className="container mx-auto px-4 py-4">
           <div className="flex justify-between items-center">
             <h1 className="text-2xl font-bold text-text-dark">Admin Dashboard</h1>
-            <form action={handleLogout}>
-              <button
-                type="submit"
-                className="bg-gray-500 text-white px-4 py-2 rounded-md hover:bg-gray-600 transition-colors"
-              >
-                Uitloggen
-              </button>
-            </form>
+            <div className="flex items-center gap-4">
+              <Link href="/admin/dashboard/audit" className="text-sm text-gray-500 hover:underline">
+                Logboek
+              </Link>
+              <form action={handleLogout}>
+                <button
+                  type="submit"
+                  className="bg-gray-500 text-white px-4 py-2 rounded-md hover:bg-gray-600 transition-colors"
+                >
+                  Uitloggen
+                </button>
+              </form>
+            </div>
           </div>
         </div>
       </div>

--- a/app/admin/dashboard/taken/[id]/edit/page.tsx
+++ b/app/admin/dashboard/taken/[id]/edit/page.tsx
@@ -16,7 +16,9 @@ export default function EditTaakPage({ params }: { params: Promise<{ id: string 
     naam: '',
     beschrijving: '',
     maxAantal: '',
-    categorie: ''
+    categorie: '',
+    tijd: '',
+    locatie: ''
   });
 
   useEffect(() => {
@@ -33,7 +35,9 @@ export default function EditTaakPage({ params }: { params: Promise<{ id: string 
           naam: task.naam,
           beschrijving: task.beschrijving || '',
           maxAantal: task.maxAantal.toString(),
-          categorie: task.categorie || ''
+          categorie: task.categorie || '',
+          tijd: task.tijd || '',
+          locatie: task.locatie || ''
         });
       } catch (err) {
         setError('Fout bij het laden van de taak');
@@ -165,6 +169,33 @@ export default function EditTaakPage({ params }: { params: Promise<{ id: string 
                 onChange={handleChange}
                 className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-primary"
               />
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="tijd" className="block text-sm font-medium text-gray-700 mb-1">Tijd</label>
+                <input
+                  type="text"
+                  id="tijd"
+                  name="tijd"
+                  placeholder="bijv. 09:30 - 12:00"
+                  value={formData.tijd}
+                  onChange={handleChange}
+                  className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-primary"
+                />
+              </div>
+              <div>
+                <label htmlFor="locatie" className="block text-sm font-medium text-gray-700 mb-1">Locatie</label>
+                <input
+                  type="text"
+                  id="locatie"
+                  name="locatie"
+                  placeholder="bijv. Grote zaal"
+                  value={formData.locatie}
+                  onChange={handleChange}
+                  className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-primary"
+                />
+              </div>
             </div>
 
             {error && (

--- a/app/admin/dashboard/taken/[id]/page.tsx
+++ b/app/admin/dashboard/taken/[id]/page.tsx
@@ -83,6 +83,14 @@ export default async function TaakDetailPage({ params }: { params: Promise<{ id:
                 {taak.aanmeldingen.length} / {taak.maxAantal}
               </dd>
             </div>
+            <div>
+              <dt className="text-sm font-medium text-gray-500">Tijd</dt>
+              <dd className="mt-1">{taak.tijd || '-'}</dd>
+            </div>
+            <div>
+              <dt className="text-sm font-medium text-gray-500">Locatie</dt>
+              <dd className="mt-1">{taak.locatie || '-'}</dd>
+            </div>
           </dl>
         </div>
 

--- a/app/admin/dashboard/taken/nieuw/page.tsx
+++ b/app/admin/dashboard/taken/nieuw/page.tsx
@@ -13,7 +13,9 @@ export default function NieuweTaakPage() {
     naam: '',
     beschrijving: '',
     maxAantal: '',
-    categorie: ''
+    categorie: '',
+    tijd: '',
+    locatie: ''
   });
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -100,6 +102,37 @@ export default function NieuweTaakPage() {
                 onChange={handleChange}
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
               />
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="tijd" className="block text-sm font-medium text-gray-700 mb-1">
+                  Tijd
+                </label>
+                <input
+                  type="text"
+                  id="tijd"
+                  name="tijd"
+                  placeholder="bijv. 09:30 - 12:00"
+                  value={formData.tijd}
+                  onChange={handleChange}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+                />
+              </div>
+              <div>
+                <label htmlFor="locatie" className="block text-sm font-medium text-gray-700 mb-1">
+                  Locatie
+                </label>
+                <input
+                  type="text"
+                  id="locatie"
+                  name="locatie"
+                  placeholder="bijv. Grote zaal"
+                  value={formData.locatie}
+                  onChange={handleChange}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+                />
+              </div>
             </div>
 
             <div>

--- a/app/api/admin/taken/[id]/route.ts
+++ b/app/api/admin/taken/[id]/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { requireAdmin } from '@/lib/api-auth';
+import { getSession } from '@/lib/auth';
+import { logAudit } from '@/lib/audit';
 import { ACTIEF_FILTER } from '@/lib/aanmelding';
+
+const str = (v: unknown, max: number) => (typeof v === 'string' && v.trim() ? v.trim().slice(0, max) : null);
 
 // GET a single task
 export async function GET(
@@ -49,7 +53,7 @@ export async function PUT(
   try {
     const { id } = await params;
     const body = await request.json();
-    const { naam, beschrijving, maxAantal, categorie } = body;
+    const { naam, beschrijving, maxAantal, categorie, tijd, locatie } = body;
 
     if (!naam || !maxAantal) {
       return NextResponse.json(
@@ -90,7 +94,17 @@ export async function PUT(
         beschrijving: beschrijving || null,
         maxAantal: parseInt(maxAantal),
         categorie: categorie || null,
+        tijd: str(tijd, 100),
+        locatie: str(locatie, 200),
       },
+    });
+
+    await logAudit({
+      actorEmail: (await getSession())?.email ?? 'onbekend',
+      action: 'taak.bewerkt',
+      entityType: 'Taak',
+      entityId: id,
+      details: updatedTaak.naam,
     });
 
     return NextResponse.json({
@@ -143,6 +157,14 @@ export async function DELETE(
     // Delete the task
     await prisma.taak.delete({
       where: { id }
+    });
+
+    await logAudit({
+      actorEmail: (await getSession())?.email ?? 'onbekend',
+      action: 'taak.verwijderd',
+      entityType: 'Taak',
+      entityId: id,
+      details: task.naam,
     });
 
     return NextResponse.json({

--- a/app/api/admin/taken/route.ts
+++ b/app/api/admin/taken/route.ts
@@ -1,13 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { requireAdmin } from '@/lib/api-auth';
+import { getSession } from '@/lib/auth';
+import { logAudit } from '@/lib/audit';
+
+const str = (v: unknown, max: number) => (typeof v === 'string' && v.trim() ? v.trim().slice(0, max) : null);
 
 export async function POST(request: NextRequest) {
   const denied = await requireAdmin();
   if (denied) return denied;
+  const session = await getSession();
   try {
     const body = await request.json();
-    const { naam, beschrijving, maxAantal, categorie } = body;
+    const { naam, beschrijving, maxAantal, categorie, tijd, locatie } = body;
 
     const aantal = parseInt(maxAantal, 10);
     if (!naam || typeof naam !== 'string' || naam.length > 200 || !Number.isInteger(aantal) || aantal < 1 || aantal > 10000) {
@@ -23,7 +28,17 @@ export async function POST(request: NextRequest) {
         beschrijving: beschrijving || null,
         maxAantal: aantal,
         categorie: categorie || null,
+        tijd: str(tijd, 100),
+        locatie: str(locatie, 200),
       },
+    });
+
+    await logAudit({
+      actorEmail: session?.email ?? 'onbekend',
+      action: 'taak.aangemaakt',
+      entityType: 'Taak',
+      entityId: taak.id,
+      details: taak.naam,
     });
 
     return NextResponse.json({


### PR DESCRIPTION
Fase 4b — tijd/locatie per taak + audit-logboek.

- **Taak: tijd + locatie** — velden in nieuw/bewerk-formulier, opgeslagen via de API, getoond op admin-taakdetail én de publieke aanmeldpagina (🕒 · 📍).
- **Audit-logging** op taak aanmaken/bewerken/verwijderen (naast de aanmelding-acties uit 4a).
- **Nieuwe pagina** `/admin/dashboard/audit`: logboek van alle beheeracties. Link "Logboek" op het dashboard.

Verified: type-check, lint, jest 39/39, build. Hiermee is Fase 4 (admin) compleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)