### PR TITLE
feat: sorteerbare kolommen + klikbare stat-filters op dashboard

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -41,8 +41,64 @@ async function handleLogout() {
   redirect('/admin/login');
 }
 
-export default async function AdminDashboard() {
+type SortKey = 'naam' | 'categorie' | 'bezetting' | 'status';
+type TaakRij = Awaited<ReturnType<typeof getStats>>['taken'][number];
+
+const bezettingsRatio = (t: TaakRij) => (t.maxAantal > 0 ? t._count.aanmeldingen / t.maxAantal : 0);
+
+function sorteerTaken(taken: TaakRij[], sort: SortKey, dir: 'asc' | 'desc') {
+  const factor = dir === 'asc' ? 1 : -1;
+  return [...taken].sort((a, b) => {
+    let cmp = 0;
+    if (sort === 'naam') cmp = a.naam.localeCompare(b.naam, 'nl');
+    else if (sort === 'categorie') cmp = (a.categorie || '').localeCompare(b.categorie || '', 'nl');
+    else cmp = bezettingsRatio(a) - bezettingsRatio(b); // bezetting + status sorteren op vullingsgraad
+    return cmp * factor;
+  });
+}
+
+const isVolTaak = (t: TaakRij) => t._count.aanmeldingen >= t.maxAantal;
+const isBijnaVol = (t: TaakRij) => !isVolTaak(t) && bezettingsRatio(t) >= 0.8;
+
+// Bouw een dashboard-URL die de huidige sortering bewaart.
+function dashboardHref(sort: SortKey, dir: 'asc' | 'desc', filter?: string, col?: SortKey, colDir?: 'asc' | 'desc') {
+  const parts: string[] = [];
+  const s = col ?? sort;
+  const d = colDir ?? dir;
+  if (s !== 'naam' || d !== 'asc') parts.push(`sort=${s}`, `dir=${d}`);
+  if (filter) parts.push(`filter=${filter}`);
+  return '/admin/dashboard' + (parts.length ? `?${parts.join('&')}` : '');
+}
+
+// Klikbare kolomheader die de sortering via de URL aanstuurt (en de filter bewaart).
+function SortHeader({ label, col, sort, dir, filter }: { label: string; col: SortKey; sort: SortKey; dir: 'asc' | 'desc'; filter?: string }) {
+  const actief = sort === col;
+  const volgendeDir: 'asc' | 'desc' = actief && dir === 'asc' ? 'desc' : 'asc';
+  const pijl = actief ? (dir === 'asc' ? '▲' : '▼') : '';
+  return (
+    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+      <Link href={dashboardHref(sort, dir, filter, col, volgendeDir)} className="inline-flex items-center gap-1 hover:text-gray-800">
+        {label}
+        <span className="text-[9px]">{pijl}</span>
+      </Link>
+    </th>
+  );
+}
+
+export default async function AdminDashboard({
+  searchParams,
+}: {
+  searchParams: Promise<{ sort?: string; dir?: string; filter?: string }>;
+}) {
   const stats = await getStats();
+  const sp = await searchParams;
+  const sort = (['naam', 'categorie', 'bezetting', 'status'].includes(sp.sort ?? '') ? sp.sort : 'naam') as SortKey;
+  const dir: 'asc' | 'desc' = sp.dir === 'desc' ? 'desc' : 'asc';
+  const filter = sp.filter === 'vol' || sp.filter === 'bijnavol' ? sp.filter : undefined;
+
+  const gesorteerd = sorteerTaken(stats.taken, sort, dir);
+  const taken =
+    filter === 'vol' ? gesorteerd.filter(isVolTaak) : filter === 'bijnavol' ? gesorteerd.filter(isBijnaVol) : gesorteerd;
 
   return (
     <main className="min-h-screen bg-bg-light">
@@ -69,25 +125,41 @@ export default async function AdminDashboard() {
 
       <div className="container mx-auto px-4 py-8">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
-          <div className="bg-white rounded-lg shadow p-6">
+          <Link
+            href={dashboardHref(sort, dir, undefined)}
+            className={`bg-white rounded-lg shadow p-6 block hover:shadow-md transition-shadow ${!filter ? 'ring-2 ring-primary' : ''}`}
+          >
             <h3 className="text-sm font-medium text-text-muted mb-2">Totaal Taken</h3>
             <p className="text-3xl font-bold text-text-dark">{stats.takenCount}</p>
-          </div>
-          
-          <div className="bg-white rounded-lg shadow p-6">
+            <p className="text-xs text-gray-400 mt-1">Toon alle taken</p>
+          </Link>
+
+          <Link
+            href="/admin/dashboard/aanmeldingen"
+            className="bg-white rounded-lg shadow p-6 block hover:shadow-md transition-shadow"
+          >
             <h3 className="text-sm font-medium text-text-muted mb-2">Totaal Aanmeldingen</h3>
             <p className="text-3xl font-bold text-text-dark">{stats.aanmeldingenCount}</p>
-          </div>
-          
-          <div className="bg-white rounded-lg shadow p-6">
+            <p className="text-xs text-gray-400 mt-1">Bekijk alle aanmeldingen →</p>
+          </Link>
+
+          <Link
+            href={dashboardHref(sort, dir, 'vol')}
+            className={`bg-white rounded-lg shadow p-6 block hover:shadow-md transition-shadow ${filter === 'vol' ? 'ring-2 ring-danger' : ''}`}
+          >
             <h3 className="text-sm font-medium text-text-muted mb-2">Volle Taken</h3>
             <p className="text-3xl font-bold text-text-dark">{stats.volletaken.length}</p>
-          </div>
-          
-          <div className="bg-white rounded-lg shadow p-6">
+            <p className="text-xs text-gray-400 mt-1">Toon welke →</p>
+          </Link>
+
+          <Link
+            href={dashboardHref(sort, dir, 'bijnavol')}
+            className={`bg-white rounded-lg shadow p-6 block hover:shadow-md transition-shadow ${filter === 'bijnavol' ? 'ring-2 ring-warning' : ''}`}
+          >
             <h3 className="text-sm font-medium text-text-muted mb-2">Bijna Vol</h3>
             <p className="text-3xl font-bold text-text-dark">{stats.bijnaVolletaken.length}</p>
-          </div>
+            <p className="text-xs text-gray-400 mt-1">Toon welke →</p>
+          </Link>
         </div>
 
         <div className="bg-white rounded-lg shadow">
@@ -122,30 +194,29 @@ export default async function AdminDashboard() {
               </div>
             </div>
           </div>
-          
+
+          {filter && (
+            <div className="px-6 py-2 bg-gray-50 border-b text-sm text-gray-600 flex items-center gap-2">
+              <span>Gefilterd op: <strong>{filter === 'vol' ? 'Volle taken' : 'Bijna volle taken'}</strong> ({taken.length})</span>
+              <Link href={dashboardHref(sort, dir, undefined)} className="text-primary hover:underline">× toon alle</Link>
+            </div>
+          )}
+
           <div className="overflow-x-auto">
             <table className="w-full">
               <thead className="bg-gray-50">
                 <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Naam
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Categorie
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Bezetting
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Status
-                  </th>
+                  <SortHeader label="Naam" col="naam" sort={sort} dir={dir} filter={filter} />
+                  <SortHeader label="Categorie" col="categorie" sort={sort} dir={dir} filter={filter} />
+                  <SortHeader label="Bezetting" col="bezetting" sort={sort} dir={dir} filter={filter} />
+                  <SortHeader label="Status" col="status" sort={sort} dir={dir} filter={filter} />
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                     Acties
                   </th>
                 </tr>
               </thead>
               <tbody className="bg-white divide-y divide-gray-200">
-                {stats.taken.map((taak) => {
+                {taken.map((taak) => {
                   const percentage = (taak._count.aanmeldingen / taak.maxAantal) * 100;
                   const isVol = taak._count.aanmeldingen >= taak.maxAantal;
                   
@@ -203,9 +274,16 @@ export default async function AdminDashboard() {
               </tbody>
             </table>
             
-            {stats.taken.length === 0 && (
+            {taken.length === 0 && (
               <div className="text-center py-8 text-text-muted">
-                Nog geen taken aangemaakt
+                {filter
+                  ? `Geen ${filter === 'vol' ? 'volle' : 'bijna volle'} taken. `
+                  : 'Nog geen taken aangemaakt'}
+                {filter && (
+                  <Link href={dashboardHref(sort, dir, undefined)} className="text-primary hover:underline">
+                    Toon alle taken
+                  </Link>
+                )}
               </div>
             )}
           </div>


### PR DESCRIPTION
Twee dashboard-verbeteringen:

- **Sorteerbare kolommen** in het takenoverzicht (Naam/Categorie/Bezetting/Status) — klik op de header, sorteert op-/aflopend via de URL (server-side). Bezetting + Status op vullingsgraad. Pijltje toont actieve sortering.
- **Klikbare stat-kaarten**: "Volle Taken" / "Bijna Vol" filteren de tabel direct naar wélke taken dat zijn (niet alleen het aantal). "Totaal Aanmeldingen" linkt naar het aanmeldingen-overzicht. Actieve filter gemarkeerd + "toon alle".

Sortering en filter blijven samen in de URL.

Verified: type-check, lint, jest 39/39, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)